### PR TITLE
Set checked property on all checkboxes before clicking

### DIFF
--- a/script.js
+++ b/script.js
@@ -16,9 +16,11 @@ if (!$('#quiet-comment-button-container').length) {
 
   $button.click(function() {
     var elements = document.getElementsByClassName('js-toggle-file-notes');
-    [].forEach.call(elements, (el) => el.click());
+    [].forEach.call(elements, function(el) {
+      el.checked = !$button.hasClass(classToggleName);
+      el.click();
+    });
     $button.toggleClass(classToggleName);
     setButtonText();
   });
 }
-


### PR DESCRIPTION
Addresses https://github.com/ernbrn/quiet-comment/issues/2

This will set the "checked" property on each "Show comments" checkbox _before_ clicking it, so all checkboxes start with the expected setting.

![mde5ys0prt](https://user-images.githubusercontent.com/7559041/35883846-b388b7b6-0b56-11e8-8989-16804a23fe9f.gif)
