### PR TITLE
Execute jquery before executing the script in the event script

### DIFF
--- a/event.js
+++ b/event.js
@@ -1,4 +1,6 @@
 chrome.webNavigation.onHistoryStateUpdated.addListener(function(details) {
-  chrome.tabs.executeScript(null, {file: "script.js"});
+  chrome.tabs.executeScript(null, {file: "jquery-3.2.1.min.js"}, function() {
+    chrome.tabs.executeScript(null, {file: "script.js"});
+  });
 }, {url: [{hostContains: 'github.', urlContains: 'pull', urlSuffix: 'files'}]});
 


### PR DESCRIPTION
Fixes #4 
When navigating to the files page, the script was being executed but the button was not appearing because jquery is not on the page. Execute the jquery script, and then in the callback execute the event page script to ensure no race conditions.

![issueresolve](https://user-images.githubusercontent.com/7637609/35889630-6ce7160e-0b6a-11e8-8569-0e1f2c75e5b9.gif)
